### PR TITLE
Add Ruby Finder

### DIFF
--- a/example/ruby/Gemfile
+++ b/example/ruby/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'appium_flutter_finder', '~> 0.1.0'
+gem 'appium_flutter_finder', '~> 0.1.1'
 gem 'appium_lib_core', '~> 3.3'
 gem 'minitest', '~> 5.0'

--- a/example/ruby/Gemfile
+++ b/example/ruby/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'appium_flutter_finder', '~> 0.1.0'
+gem 'appium_lib_core', '~> 3.3'
+gem 'minitest', '~> 5.0'

--- a/example/ruby/example.rb
+++ b/example/ruby/example.rb
@@ -1,0 +1,59 @@
+require 'appium_lib_core'
+require 'appium_flutter_finder'
+
+require 'minitest/autorun'
+
+class ExampleTests < Minitest::Test
+  include ::Appium::Flutter::Finder
+
+  IOS_CAPS = {
+    caps: {
+      platformName: 'iOS',
+      automationName: 'flutter',
+      platformVersion: '12.4',
+      deviceName: 'iPhone 8',
+      app: "#{Dir.pwd}/../app/app/Runner.zip"
+    },
+    appium_lib: {
+      export_session: true,
+      wait_timeout: 20,
+      wait_interval: 1
+    }
+  }.freeze
+
+  def test_run_example_ios_scenario
+    @core = ::Appium::Core.for(IOS_CAPS)
+    @driver = @core.start_driver
+
+
+    # [debug] [MJSONWP (044613d9)] Calling AppiumDriver.getText() with args: ["eyJmaW5kZXJUeXBlIjoiQnlWYWx1ZUtleSIsImtleVZhbHVlU3RyaW5nIjoiY291bnRlciIsImtleVZhbHVlVHlwZSI6IlN0cmluZyJ9","044613d9-d722-4624-b32a-5c5369b2905d"]
+    # [debug] [FlutterDriver] Executing Flutter driver command 'getText'
+    # [debug] [FlutterDriver] >>> {"command":"get_text","finderType":"ByValueKey","keyValueString":"counter","keyValueType":"String"}
+    # counter_text_finder  = by_value_key 'counter'
+    # Appium::Flutter::Element.new(@driver, finder: counter_text_finder).text
+    #
+    # button_finder = by_value_key 'increment'
+    # Appium::Flutter::Element.new(@driver, finder: button_finder).click
+
+
+    # [HTTP] --> GET /wd/hub/session/c197c17b-640b-4945-b2ae-70dd951e1546/element/eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IllvdSBoYXZlIHB1c2hlZCB0aGUgYnV0dG9uIHRoaXMgbWFueSB0aW1lczoifQ==/text
+    # [HTTP] {}
+    # [debug] [MJSONWP (c197c17b)] Calling AppiumDriver.getText() with args: ["eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IllvdSBoYXZlIHB1c2hlZCB0aGUgYnV0dG9uIHRoaXMgbWFueSB0aW1lczoifQ==","c197c17b-640b-4945-b2ae-70dd951e1546"]
+    # [debug] [FlutterDriver] Executing Flutter driver command 'getText'
+    # [debug] [FlutterDriver] >>> {"command":"get_text","finderType":"ByText","text":"You have pushed the button this many times:"}
+    # [debug] [FlutterDriver] <<< {"isError":false,"response":{"text":"You have pushed the button this many times:"},"type":"_extensionType","method":"ext.flutter.driver"} | previous command get_text
+    # [debug] [MJSONWP (c197c17b)] Responding to client with driver.getText() result: "You have pushed the button this many times:"
+    # [HTTP] <-- GET /wd/hub/session/c197c17b-640b-4945-b2ae-70dd951e1546/element/eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IllvdSBoYXZlIHB1c2hlZCB0aGUgYnV0dG9uIHRoaXMgbWFueSB0aW1lczoifQ==/text 200 23 ms - 117
+    # [HTTP]
+    text_finder = by_text 'You have pushed the button this many times:'
+    element = ::Appium::Flutter::Element.new(@driver, finder: text_finder)
+    assert_equal 'You have pushed the button this many times:', element.text
+
+    @driver.execute_script 'flutter:getRenderTree'
+
+    # [debug] [FlutterDriver] >>> {"command":"get_diagnostics_tree","finderType":"ByText","text":"You have pushed the button this many times:","diagnosticsType":"renderObject","includeProperties":true,"subtreeDepth":2}
+    # @driver.execute_script 'flutter:getRenderObjectDiagnostics', text_finder, { includeProperties: true }
+
+    assert_equal 'ok', @driver.execute_script('flutter:checkHealth', {})
+  end
+end

--- a/finder/ruby/Gemfile
+++ b/finder/ruby/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in appium_flutter_finder.gemspec
+gemspec

--- a/finder/ruby/Gemfile
+++ b/finder/ruby/Gemfile
@@ -1,6 +1,2 @@
-source "https://rubygems.org"
-
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-# Specify your gem's dependencies in appium_flutter_finder.gemspec
+source 'https://rubygems.org'
 gemspec

--- a/finder/ruby/README.md
+++ b/finder/ruby/README.md
@@ -1,0 +1,35 @@
+# AppiumFlutterFinder
+
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/appium_flutter_finder`. To experiment with that code, run `bin/console` for an interactive prompt.
+
+TODO: Delete this and the text above, and describe your gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'appium_flutter_finder'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install appium_flutter_finder
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/appium_flutter_finder.

--- a/finder/ruby/README.md
+++ b/finder/ruby/README.md
@@ -1,8 +1,6 @@
 # AppiumFlutterFinder
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/appium_flutter_finder`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Ruby finder elements for https://github.com/truongsinh/appium-flutter-driver
 
 ## Installation
 
@@ -22,8 +20,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
 
+```ruby
+include Appium::Flutter::Finder
+
+@driver = ::Appium::Core.for(caps).start_driver
+
+# Send a request to an element
+element = Appium::Flutter::Element.new(
+  @driver,
+  finder: by_text('You have pushed the button this many times:')
+)
+assert element.text == 'You have pushed the button this many times:'
+
+# Get render tree by Flutter
+@driver.execute_script 'flutter:getRenderTree', {}
+```
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
@@ -32,4 +44,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/appium_flutter_finder.
+Bug reports and pull requests are welcome on GitHub at https://github.com/truongsinh/appium-flutter-driver/tree/master/finder/ruby .

--- a/finder/ruby/Rakefile
+++ b/finder/ruby/Rakefile
@@ -1,0 +1,10 @@
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task default: :test

--- a/finder/ruby/appium_flutter_finder.gemspec
+++ b/finder/ruby/appium_flutter_finder.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.name          = 'appium_flutter_finder'
-  spec.version       = AppiumFlutterFinder::VERSION
+  spec.version       = Appium::Flutter::Finder::VERSION
   spec.authors       = ['Kazuaki Matsuo']
   spec.email         = ['fly.49.89.over@gmail.com']
 
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'appium_lib_core', '~> 3.3'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/finder/ruby/appium_flutter_finder.gemspec
+++ b/finder/ruby/appium_flutter_finder.gemspec
@@ -1,0 +1,29 @@
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'appium_flutter_finder/version'
+
+Gem::Specification.new do |spec|
+  spec.required_ruby_version = '>= 2.2'
+
+  spec.name          = 'appium_flutter_finder'
+  spec.version       = AppiumFlutterFinder::VERSION
+  spec.authors       = ['Kazuaki Matsuo']
+  spec.email         = ['fly.49.89.over@gmail.com']
+
+  spec.summary       = 'Finder for appium-flutter-driver'
+  spec.description   = 'Finder for appium-flutter-driver'
+  spec.homepage      = 'https://github.com/truongsinh/appium-flutter-driver'
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rake', '~> 10.0'
+end

--- a/finder/ruby/appium_flutter_finder.gemspec
+++ b/finder/ruby/appium_flutter_finder.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'appium_lib_core', '~> 3.3'
+  spec.add_runtime_dependency 'appium_lib_core', '>= 3.4.2', '~> 3.4'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/finder/ruby/bin/console
+++ b/finder/ruby/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'appium_flutter_finder'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/finder/ruby/bin/setup
+++ b/finder/ruby/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/finder/ruby/lib/appium_flutter_finder.rb
+++ b/finder/ruby/lib/appium_flutter_finder.rb
@@ -1,0 +1,99 @@
+require 'json'
+require 'base64'
+
+require 'appium_flutter_finder/version'
+
+module AppiumFlutterFinder
+  # test cases: https://github.com/truongsinh/appium-flutter-driver/blob/7f56d739c429990eb30f1c82afd45e37f38939df/finder/kotlin/src/test/kotlin/pro/truongsinh/appium_flutter/finder/FinderTest.kt
+  def by_ancestor
+    # export const ancestor = (args: {
+    #     of: SerializableFinder;
+    # matching: SerializableFinder;
+    # matchRoot?: boolean;
+    # }) => {
+    #     const { of, matching, matchRoot = false } = args;
+    # const a: any = {
+    #     finderType: `Ancestor`,
+    #     matchRoot,
+    # };
+    # Object.entries(deserialize(of)).forEach(
+    #     ([key, value]) => (a[`of_${key}`] = value),
+    #     );
+    # Object.entries(deserialize(matching)).forEach(
+    #     ([key, value]) => (a[`matching_${key}`] = value),
+    #     );
+    # return serialize(a);
+    # };
+  end
+
+  def by_semantics_label(label)
+    serialize(
+      finderType: 'BySemanticsLabel',
+      isRegExp: label.is_a?(Regexp),
+      # Should be '/a/' as String in regex case
+      label: label.is_a?(Regexp) ? label.source : label
+    )
+  end
+
+  def by_tooltip(text)
+    serialize(
+      finderType: 'ByTooltipMessage',
+      text: text
+    )
+  end
+
+  def by_type(type)
+    serialize(
+      finderType: 'ByType',
+      type: type
+    )
+  end
+
+  def by_value_key(key)
+    serialize(
+      finderType: 'ByValueKey',
+      keyValueString: key,
+      keyValueType: key.is_a?(String) ? 'String' : 'int'
+    )
+  end
+
+  def by_descendant
+    # export const descendant = (args: {
+    #     of: SerializableFinder;
+    # matching: SerializableFinder;
+    # matchRoot?: boolean;
+    # }) => {
+    #     const { of, matching, matchRoot = false } = args;
+    # const a: any = {
+    #     finderType: `Descendant`,
+    #     matchRoot,
+    # };
+    # Object.entries(deserialize(of)).forEach(
+    #     ([key, value]) => (a[`of_${key}`] = value),
+    #     );
+    # Object.entries(deserialize(matching)).forEach(
+    #     ([key, value]) => (a[`matching_${key}`] = value),
+    #     );
+    # return serialize(a);
+    # };
+  end
+
+  def page_back
+    serialize(
+      finderType: 'PageBack'
+    )
+  end
+
+  def by_text(text)
+    serialize(
+      finderType: 'ByText',
+      text: text
+    )
+  end
+
+  private
+
+  def serialize(hash)
+    Base64.strict_encode64(hash.to_json)
+  end
+end

--- a/finder/ruby/lib/appium_flutter_finder.rb
+++ b/finder/ruby/lib/appium_flutter_finder.rb
@@ -1,99 +1,114 @@
 require 'json'
 require 'base64'
 
+require 'appium_lib_core'
 require 'appium_flutter_finder/version'
 
-module AppiumFlutterFinder
-  def by_ancestor(serialized_finder:, matching:, match_root: false)
-    by_ancestor_or_descendant(
-      type: 'Ancestor',
-      serialized_finder: serialized_finder,
-      matching: matching,
-      match_root: match_root
-    )
-  end
+module Appium
+  module Flutter
 
-  def by_descendant(serialized_finder:, matching:, match_root: false)
-    by_ancestor_or_descendant(
-      type: 'Descendant',
-      serialized_finder: serialized_finder,
-      matching: matching,
-      match_root: match_root
-    )
-  end
-
-  def by_semantics_label(label)
-    serialize(
-      finderType: 'BySemanticsLabel',
-      isRegExp: label.is_a?(Regexp),
-      # Should be '/a/' as String in regex case
-      label: label.is_a?(Regexp) ? label.source : label
-    )
-  end
-
-  def by_tooltip(text)
-    serialize(
-      finderType: 'ByTooltipMessage',
-      text: text
-    )
-  end
-
-  def by_type(type)
-    serialize(
-      finderType: 'ByType',
-      type: type
-    )
-  end
-
-  def by_value_key(key)
-    serialize(
-      finderType: 'ByValueKey',
-      keyValueString: key,
-      keyValueType: key.is_a?(String) ? 'String' : 'int'
-    )
-  end
-
-  def page_back
-    serialize(
-      finderType: 'PageBack'
-    )
-  end
-
-  def by_text(text)
-    serialize(
-      finderType: 'ByText',
-      text: text
-    )
-  end
-
-  private
-
-  def serialize(hash)
-    Base64.strict_encode64(hash.to_json)
-  end
-
-  def by_ancestor_or_descendant(type:, serialized_finder:, matching:, match_root: false)
-    param = { finderType: type, matchRoot: match_root }
-
-    finder = begin
-      JSON.parse(Base64.decode64(serialized_finder))
-    rescue JSONError
-      {}
+    # Handles flutter elements as Appium Elements
+    class Element < ::Selenium::WebDriver::Element
+      def initialize(driver, finder:)
+        @bridge = driver.send :bridge
+        @id = finder
+      end
     end
 
-    finder.each_key do |key|
-      param["of_#{key}"] = finder[key]
-    end
+    # Get find element context for flutter driver
+    module Finder
+      def by_ancestor(serialized_finder:, matching:, match_root: false)
+        by_ancestor_or_descendant(
+          type: 'Ancestor',
+          serialized_finder: serialized_finder,
+          matching: matching,
+          match_root: match_root
+        )
+      end
 
-    matching = begin
-      JSON.parse(Base64.decode64(matching))
-    rescue JSONError
-      {}
-    end
-    matching.each_key do |key|
-      param["matching_#{key}"] = matching[key]
-    end
+      def by_descendant(serialized_finder:, matching:, match_root: false)
+        by_ancestor_or_descendant(
+          type: 'Descendant',
+          serialized_finder: serialized_finder,
+          matching: matching,
+          match_root: match_root
+        )
+      end
 
-    serialize param
+      def by_semantics_label(label)
+        serialize(
+          finderType: 'BySemanticsLabel',
+          isRegExp: label.is_a?(Regexp),
+          # Should be '/a/' as String in regex case
+          label: label.is_a?(Regexp) ? label.source : label
+        )
+      end
+
+      def by_tooltip(text)
+        serialize(
+          finderType: 'ByTooltipMessage',
+          text: text
+        )
+      end
+
+      def by_type(type)
+        serialize(
+          finderType: 'ByType',
+          type: type
+        )
+      end
+
+      def by_value_key(key)
+        serialize(
+          finderType: 'ByValueKey',
+          keyValueString: key,
+          keyValueType: key.is_a?(String) ? 'String' : 'int'
+        )
+      end
+
+      def page_back
+        serialize(
+          finderType: 'PageBack'
+        )
+      end
+
+      def by_text(text)
+        serialize(
+          finderType: 'ByText',
+          text: text
+        )
+      end
+
+      private
+
+      def serialize(hash)
+        Base64.strict_encode64(hash.to_json)
+      end
+
+      def by_ancestor_or_descendant(type:, serialized_finder:, matching:, match_root: false)
+        param = { finderType: type, matchRoot: match_root }
+
+        finder = begin
+          JSON.parse(Base64.decode64(serialized_finder))
+        rescue JSONError
+          {}
+        end
+
+        finder.each_key do |key|
+          param["of_#{key}"] = finder[key]
+        end
+
+        matching = begin
+          JSON.parse(Base64.decode64(matching))
+        rescue JSONError
+          {}
+        end
+        matching.each_key do |key|
+          param["matching_#{key}"] = matching[key]
+        end
+
+        serialize param
+      end
+    end
   end
 end

--- a/finder/ruby/lib/appium_flutter_finder.rb
+++ b/finder/ruby/lib/appium_flutter_finder.rb
@@ -10,7 +10,7 @@ module Appium
     # Handles flutter elements as Appium Elements
     class Element < ::Selenium::WebDriver::Element
       def initialize(driver, finder:)
-        @bridge = driver.send :bridge
+        @bridge = driver.bridge
         @id = finder
       end
     end

--- a/finder/ruby/lib/appium_flutter_finder/version.rb
+++ b/finder/ruby/lib/appium_flutter_finder/version.rb
@@ -1,0 +1,3 @@
+module AppiumFlutterFinder
+  VERSION = "0.1.0"
+end

--- a/finder/ruby/lib/appium_flutter_finder/version.rb
+++ b/finder/ruby/lib/appium_flutter_finder/version.rb
@@ -1,3 +1,7 @@
-module AppiumFlutterFinder
-  VERSION = "0.1.0"
+module Appium
+  module Flutter
+    module Finder
+      VERSION = '0.1.0'.freeze
+    end
+  end
 end

--- a/finder/ruby/lib/appium_flutter_finder/version.rb
+++ b/finder/ruby/lib/appium_flutter_finder/version.rb
@@ -1,7 +1,7 @@
 module Appium
   module Flutter
     module Finder
-      VERSION = '0.1.0'.freeze
+      VERSION = '0.1.1'.freeze
     end
   end
 end

--- a/finder/ruby/test/appium_flutter_finder_test.rb
+++ b/finder/ruby/test/appium_flutter_finder_test.rb
@@ -4,6 +4,38 @@ require_relative '../lib/appium_flutter_finder'
 class AppiumFlutterFinderTest < Minitest::Test
   include AppiumFlutterFinder
 
+  def test_by_ancestor
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaFJvb3QiOmZhbHNlLCJvZl9maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJvZl9tYXRjaFJvb3QiOmZhbHNlLCJvZl9vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJvZl9tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==',
+      by_ancestor(
+        serialized_finder: by_ancestor(
+          serialized_finder: page_back,
+          matching: page_back
+        ),
+        matching: by_ancestor(
+          serialized_finder: page_back,
+          matching: page_back
+        )
+      )
+    )
+  end
+
+  def test_by_descendant
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiRGVzY2VuZGFudCIsIm1hdGNoUm9vdCI6ZmFsc2UsIm9mX2ZpbmRlclR5cGUiOiJEZXNjZW5kYW50Iiwib2ZfbWF0Y2hSb290IjpmYWxzZSwib2Zfb2ZfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwib2ZfbWF0Y2hpbmdfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwibWF0Y2hpbmdfZmluZGVyVHlwZSI6IkRlc2NlbmRhbnQiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==',
+      by_descendant(
+        serialized_finder: by_descendant(
+          serialized_finder: page_back,
+          matching: page_back
+        ),
+        matching: by_descendant(
+          serialized_finder: page_back,
+          matching: page_back
+        )
+      )
+    )
+  end
+
   def test_by_semantics_label
     assert_equal(
       'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjpmYWxzZSwibGFiZWwiOiJzaW1wbGUifQ==',
@@ -49,7 +81,6 @@ class AppiumFlutterFinderTest < Minitest::Test
   def test_page_back
     assert_equal 'eyJmaW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==', page_back
   end
-
 
   def test_by_text
     assert_equal(

--- a/finder/ruby/test/appium_flutter_finder_test.rb
+++ b/finder/ruby/test/appium_flutter_finder_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require_relative '../lib/appium_flutter_finder'
 
 class AppiumFlutterFinderTest < Minitest::Test
-  include AppiumFlutterFinder
+  include Appium::Flutter::Finder
 
   def test_by_ancestor
     assert_equal(

--- a/finder/ruby/test/appium_flutter_finder_test.rb
+++ b/finder/ruby/test/appium_flutter_finder_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+require_relative '../lib/appium_flutter_finder'
+
+class AppiumFlutterFinderTest < Minitest::Test
+  include AppiumFlutterFinder
+
+  def test_by_semantics_label
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjpmYWxzZSwibGFiZWwiOiJzaW1wbGUifQ==',
+      by_semantics_label('simple')
+    )
+  end
+
+  def test_by_semantics_label_regex
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjp0cnVlLCJsYWJlbCI6ImNvbXBsaWNhdGVkIn0=',
+      by_semantics_label(/complicated/)
+    )
+  end
+
+  def test_by_tooltip
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQnlUb29sdGlwTWVzc2FnZSIsInRleHQiOiJteVRleHQifQ==',
+      by_tooltip('myText')
+    )
+  end
+
+  def test_by_type
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQnlUeXBlIiwidHlwZSI6Im15VGV4dCJ9',
+      by_type('myText')
+    )
+  end
+
+  def test_by_key_value_int
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQnlWYWx1ZUtleSIsImtleVZhbHVlU3RyaW5nIjo0Miwia2V5VmFsdWVUeXBlIjoiaW50In0=',
+      by_value_key(42)
+    )
+  end
+
+  def test_by_key_value_string
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQnlWYWx1ZUtleSIsImtleVZhbHVlU3RyaW5nIjoiNDIiLCJrZXlWYWx1ZVR5cGUiOiJTdHJpbmcifQ==',
+      by_value_key('42')
+    )
+  end
+
+  def test_page_back
+    assert_equal 'eyJmaW5kZXJUeXBlIjoiUGFnZUJhY2sifQ==', page_back
+  end
+
+
+  def test_by_text
+    assert_equal(
+      'eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IlRoaXMgaXMgMm5kIHJvdXRlIn0=',
+      by_text('This is 2nd route')
+    )
+  end
+end

--- a/finder/ruby/test/test_helper.rb
+++ b/finder/ruby/test/test_helper.rb
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'appium_flutter_finder'
+
+require 'minitest/autorun'


### PR DESCRIPTION
example/ruby/example.rb is not enough than Kotlin and JS, but I ensured finder syntax worked.

Actions against elements will be like below. In general, Appium/Selenium element expects users do not handle them from initialisation (`.new`), but we must give `id` as base 64 string. So, I wrapped it as `Appium::Flutter::Element` for like below syntax.

```ruby
element = Appium::Flutter::Element.new(
  @driver,
  finder: by_text('You have pushed the button this many times:')
)
assert element.text == 'You have pushed the button this many times:'
```