### PR TITLE
python: fix b64encode error

### DIFF
--- a/finder/python/README.md
+++ b/finder/python/README.md
@@ -36,3 +36,10 @@ pip install twine
 python setup.py sdist
 twine upload dist/Appium-Flutter-Finder-X.X.tar.gz
 ```
+
+# Changelog
+
+- 0.1.2
+    - Fix b64encode error in Python 3
+- 0.1.1
+    - Initial release

--- a/finder/python/appium_flutter_finder/flutter_finder.py
+++ b/finder/python/appium_flutter_finder/flutter_finder.py
@@ -3,6 +3,13 @@ import json
 
 from appium.webdriver.webelement import WebElement
 
+def _bytes(value):
+    try:
+        return bytes(value, 'UTF-8')  # Python 3
+    except TypeError:
+        return value  # Python 2
+
+
 class FlutterElement(WebElement):
     def __init__(self, driver, element_id):
         super(FlutterElement, self).__init__(
@@ -65,7 +72,7 @@ class FlutterFinder(object):
         ))
 
     def _serialize(self, finder_dict):
-        return base64.b64encode(json.dumps(finder_dict))
+        return base64.b64encode(_bytes(json.dumps(finder_dict))).decode('UTF-8')
 
     def _by_ancestor_or_descendant(self, type_, serialized_finder, matching, match_root=False):
         param = dict(finderType=type_, matchRoot=match_root)

--- a/finder/python/setup.py
+++ b/finder/python/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='Appium-Flutter-Finder',
-    version='0.1.1',
+    version='0.1.2',
     description='An extention of finder for Appium flutter',
     long_description=io.open(os.path.join(os.path.dirname('__file__'), 'README.md'), encoding='utf-8').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
`b64encode` behaves differently on Python 2 and 3.
As the same as Appium, let me add a workaround