### PR TITLE
Add code to support desired_capabilities can set retryBackoffTime and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Your Flutter app-under-test (AUT) must be compiled in `debug` or `profile` mode,
 
 This snippet, taken from [example dir](https://github.com/truongsinh/appium-flutter-driver/tree/master/example), is a script written as an appium client with `webdriverio`, and assumes you have `appium` server (with `appium-flutter-driver` installed) running on the same host and default port (`4723`). For more info, see example's [README.md](https://github.com/truongsinh/appium-flutter-driver/tree/master/example/README.md)
 
+### Desired Capabilities for flutter driver only 
+
+
+| Capability | Description | Example Values |
+| - | - | -|
+| retryBackoffTime | the time wait for socket connection retry for get flutter session (default 300000ms)|500|
+| maxRetryCount    | the count for socket connection retry for get flutter session (default 10)          | 20|
+
+
+
+	
+
 ```js
 const wdio = require('webdriverio');
 const assert = require('assert');
@@ -60,7 +72,8 @@ const opts = {
   port: 4723,
   capabilities: {
     ...osSpecificOps,
-    automationName: 'Flutter'
+    automationName: 'Flutter',
+    retryBackoffTime: 500
   }
 };
 

--- a/driver/lib/desired-caps.ts
+++ b/driver/lib/desired-caps.ts
@@ -13,6 +13,8 @@ export interface IDesiredCapConstraints {
   app: any;
   avd: any;
   udid: any;
+  retryBackoffTime: any;
+  maxRetryCount: any;
 }
 
 export const desiredCapConstraints: IDesiredCapConstraints = {
@@ -37,5 +39,11 @@ export const desiredCapConstraints: IDesiredCapConstraints = {
   },
   udid: {
     isString: true,
+  },
+  retryBackoffTime: {
+    isNumber: true,
+  },
+  maxRetryCount: {
+    isNumber: true,
   },
 };

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -25,7 +25,7 @@ export const startAndroidSession = async (caps) => {
   const observatoryWsUri = getObservatoryWsUri(androiddriver);
   return Promise.all([
     androiddriver,
-    connectSocket(await observatoryWsUri),
+    connectSocket(await observatoryWsUri, caps.retryBackoffTime ,caps.maxRetryCount),
   ]);
 
 };

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -22,7 +22,7 @@ export const startIOSSession = async (caps) => {
   const observatoryWsUri = getObservatoryWsUri(iosdriver);
   return Promise.all([
     iosdriver,
-    connectSocket(observatoryWsUri),
+    connectSocket(observatoryWsUri, caps.retryBackoffTime ,caps.maxRetryCount),
   ]);
 };
 

--- a/driver/lib/sessions/observatory.ts
+++ b/driver/lib/sessions/observatory.ts
@@ -7,15 +7,12 @@ import { deserialize } from '../../../finder/nodejs/lib/deserializer';
 import { FlutterDriver } from '../driver';
 import { log } from '../logger';
 
-const MAX_RETRY_COUNT = 10;
-const RETRY_BACKOFF = 300000;
-
 class WebSocketDummy { }
 
 export type NullableWebSocketDummy = WebSocketDummy | null;
 
 // SOCKETS
-export const connectSocket = async (dartObservatoryURL: string) => {
+export const connectSocket = async (dartObservatoryURL: string,RETRY_BACKOFF: any=300000,MAX_RETRY_COUNT: any=10) => {
   let retryCount = 0;
   let connectedSocket: NullableWebSocketDummy = null;
   while (retryCount < MAX_RETRY_COUNT && !connectedSocket) {


### PR DESCRIPTION
… maxRetryCount instead of hard code to 30000 and 10:

eg：
        desired_capabilities = {
            'app': appPtah,
            'platformName': 'Android',
            'platformVersion': '10',
            'deviceName': 'Android Emulator',
            # 'noReset': False,
            #'fullReset': True,
            'automationName': 'Flutter',

            'avd': 'Pixel_3a_XL_API_29',
            'autoGrantPermissions': 'true',
            'retryBackoffTime': 500,
        }
have try the code on local environment, can resolve if our flutter session started a little late must wait for 5 minus issue and set default value to original value, hope can approve this pr.