### PR TITLE
update package.json with appium 2.0 metadata

### DIFF
--- a/driver/package.json
+++ b/driver/package.json
@@ -13,6 +13,15 @@
     "url": "git+https://github.com/truongsinh/appium-flutter-driver.git"
   },
   "main": "./build/driver/lib/driver.js",
+  "appium": {
+    "driverName": "flutter",
+    "automationName": "Flutter",
+    "platformNames": [
+      "iOS",
+      "Android"
+    ],
+    "mainClass": "FlutterDriver"
+  },
   "bin": {},
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
This will allow the flutter driver to run from within Appium 2.0. Please advise if platformNames should include something additional besides iOS or Android.