### PR TITLE
Fix the iproxy

### DIFF
--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -32,20 +32,15 @@ export const getObservatoryWsUri = async (proxydriver) => {
   if (realDevice) {
     // @todo check if `brew install usbmuxd` is needed
     log.info(`Running on iOS real device, doing "iproxy" now`);
-    const args = [urlObject.port, urlObject.port, udid];
-    log.debug(`iproxy ${urlObject.port} ${urlObject.port} ${udid}`);
+    const args = [`${urlObject.port}:${urlObject.port}`, "-u", udid];
+    log.debug(`Executing iproxy ${urlObject.port}:${urlObject.port} -u ${udid}`);
     const cmd = spawn(`iproxy`, args);
-    let stdout = ``;
-    cmd.stdout.on(`data`, (data) => {
-      stdout += data;
-      if (stdout.includes(`waiting for connection`)) {
-        log.info(`"iproxy" started successfully`);
-      } else {
-        log.debug(`"iproxy" not started successfully ${stdout}`);
-      }
+    cmd.stderr.on('data', (data) => {
+      log.error(`iproxy stderr: ${data}`);
     });
   } else {
     log.info(`Running on iOS simulator, no "iproxy" needed`);
   }
+
   return urlObject.toJSON();
 };


### PR DESCRIPTION
Fixing the `iproxy` again. 😄  

I have tested locally and it works fine. There might be a race condition in rare case. Sometimea the proxy setup can take a little longer. When that happens the user will still have to retry in 300 seconds. Then it will work again.

I found this [default waiting](https://github.com/truongsinh/appium-flutter-driver/blob/master/driver/lib/sessions/observatory.ts#L11) is quite long. Not sure if there is a reason behind. This can however be overwritten by adding something like `retryBackoffTime=3000` in the desired capabilities. So it is not a big thing if it is documented somewhere.
