### PR TITLE
feat: remove iproxy dependencies to reduce deps

### DIFF
--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -31,8 +31,8 @@ export const getObservatoryWsUri = async (proxydriver) => {
   const urlObject = processLogToGetobservatory(proxydriver.logs.syslog.logs);
   const { udid } = proxydriver.opts;
 
-  if (proxydriver.isRealDevice) {
-    log.info(`Running on iOS real device`);
+  if (proxydriver.isRealDevice()) {
+    log.info('Running on iOS real device');
     const localServer = net.createServer(async (localSocket) => {
       let remoteSocket;
       try {
@@ -43,7 +43,6 @@ export const getObservatoryWsUri = async (proxydriver) => {
       }
 
       const destroyCommChannel = () => {
-        log.info(`Unbinding socket to the port: ${urlObject.port}`);
         remoteSocket.unpipe(localSocket);
         localSocket.unpipe(remoteSocket);
       };
@@ -62,7 +61,7 @@ export const getObservatoryWsUri = async (proxydriver) => {
     localServer.listen(urlObject.port);
     log.info(`Port forwarding to: ${urlObject.port}`);
   } else {
-    log.info(`Running on iOS simulator, no "iproxy" needed`);
+    log.info('Running on iOS simulator');
   }
 
   return urlObject.toJSON();

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -28,13 +28,7 @@ export const startIOSSession = async (caps) => {
 };
 
 export const getObservatoryWsUri = async (proxydriver) => {
-  let urlObject;
-  try {
-    urlObject = processLogToGetobservatory(proxydriver.logs.syslog.logs);
-  } catch (err) {
-    log.errorAndThrow(`Failed to get the device log: ${err.message}`);
-  };
-
+  const urlObject = processLogToGetobservatory(proxydriver.logs.syslog.logs);
   const { udid } = proxydriver.opts;
 
   if (proxydriver.isRealDevice()) {

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -28,7 +28,13 @@ export const startIOSSession = async (caps) => {
 };
 
 export const getObservatoryWsUri = async (proxydriver) => {
-  const urlObject = processLogToGetobservatory(proxydriver.logs.syslog.logs);
+  let urlObject;
+  try {
+    urlObject = processLogToGetobservatory(proxydriver.logs.syslog.logs);
+  } catch (err) {
+    log.errorAndThrow(`Failed to get the device log: ${err.message}`);
+  };
+
   const { udid } = proxydriver.opts;
 
   if (proxydriver.isRealDevice()) {

--- a/driver/package.json
+++ b/driver/package.json
@@ -47,6 +47,7 @@
     "appium-uiautomator2-driver": "^1.35.1",
     "appium-xcuitest-driver": "^3.17.0",
     "rpc-websockets": "^5.1.1",
-    "appium-adb": "^8.8.0"
+    "appium-adb": "^8.8.0",
+    "appium-ios-device": "^1.7.1"
   }
 }


### PR DESCRIPTION
In the fact, Appium already has a native communication channel with iOS devices over usbmuxd.
It helps to remove iproxy related dependencies from Appium toolchain.

~~I'll tweak a bit more, but this works like below.~~ <= finished

```
[WD Proxy] Determined the downstream protocol as 'W3C'
[debug] [BaseDriver] Event 'wdaSessionStarted' logged at 1611733324052 (23:42:04 GMT-0800 (Pacific Standard Time))
[debug] [BaseDriver] Event 'wdaStarted' logged at 1611733324052 (23:42:04 GMT-0800 (Pacific Standard Time))
[XCUITest] Skipping setting of the initial display orientation. Set the "orientation" capability to either "LANDSCAPE" or "PORTRAIT", if this is an undesired behavior.
[debug] [BaseDriver] Event 'orientationSet' logged at 1611733324053 (23:42:04 GMT-0800 (Pacific Standard Time))
[debug] [BaseDriver] The value of 'elementResponseAttributes' setting did not change. Skipping the update for it
[debug] [BaseDriver] The value of 'shouldUseCompactResponses' setting did not change. Skipping the update for it
[FlutterDriver] Running on iOS real device
[FlutterDriver] Port forwarding to: 52315
[FlutterDriver] Attempt #1
[FlutterDriver] Connecting to Dart Observatory: ws://127.0.0.1:52315/GouxPMom7Ps=/ws
[FlutterDriver] Connected to ws://127.0.0.1:52315/GouxPMom7Ps=/ws
[FlutterDriver] Listing all isolates: [{"type":"@Isolate","id":"isolates/2023349861633679","name":"main","number":"2023349861633679","isSystemIsolate":false}]
[Appium] New FlutterDriver session created successfully, session f11fd0e0-9416-4d39-9136-3cb2d4df1055 added to master session list
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1611733324492 (23:42:04 GMT-0800 (Pacific Standard Time))
[debug] [MJSONWP (f11fd0e0)] Cached the protocol value 'MJSONWP' for the new session f11fd0e0-9416-4d39-9136-3cb2d4df1055
[debug] [MJSONWP (f11fd0e0)] Responding to client with driver.createSession() result: {"shell":false,"allowCors":false,"reboot":false,"ipa":null,"address":"0.0.0.0","port":4723,"basePath":"/wd/hub","keepAliveTimeout":null,"callbackAddress":null,"callbackPort":null,"bootstrapPort":4724,"backendRetries":3,"sessionOverride":false,"launch":false,"logFile":null,"loglevel":"debug","logTimestamp":false,"localTimezone":false,"logNoColors":false,"webhook":null,"safari":false,"defaultDevice":false,"forceIphone":false,"forceIpad":false,"automationTraceTemplatePath":null,"instrumentsPath":null,"nodeconfig":null,"robotAddress":"0.0.0.0","robotPort":-1,"chromedriverExecutable":null,"showConfig":false,"noPermsCheck":false,"enforceStrictCaps":false,"isolateSimDevice":false,"tmpDir":"/var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T","traceDir":null,"debugLogSpacing":false,"suppressKillServer":false,"longStacktrace":false,"webkitDebugProxyPort":27753,"wdaLocalPort":8100,"defaultCapabilities":{},"relaxedSecurityEnabled":false,"allowInsecure":[],"denyInsecure":[],"defaultCommandTimeout":60,"keepArtifacts":fals...
[HTTP] <-- POST /wd/hub/session 200 6428 ms - 2162
[HTTP]
[HTTP] --> POST /wd/hub/session/f11fd0e0-9416-4d39-9136-3cb2d4df1055/timeouts/implicit_wait
[HTTP] {"ms":0}
[debug] [MJSONWP (f11fd0e0)] Calling AppiumDriver.implicitWait() with args: [0,"f11fd0e0-9416-4d39-9136-3cb2d4df1055"]
[debug] [FlutterDriver] Executing Flutter driver command 'implicitWait'
[debug] [BaseDriver] Set implicit wait to 0ms
[debug] [MJSONWP (f11fd0e0)] Responding to client with driver.implicitWait() result: null
[HTTP] <-- POST /wd/hub/session/f11fd0e0-9416-4d39-9136-3cb2d4df1055/timeouts/implicit_wait 200 4 ms - 76
[HTTP]

[HTTP] --> GET /wd/hub/session/f11fd0e0-9416-4d39-9136-3cb2d4df1055/element/eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IllvdSBoYXZlIHB1c2hlZCB0aGUgYnV0dG9uIHRoaXMgbWFueSB0aW1lczoifQ==/text
[HTTP] {}
[debug] [MJSONWP (f11fd0e0)] Calling AppiumDriver.getText() with args: ["eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IllvdSBoYXZlIHB1c2hlZCB0aGUgYnV0dG9uIHRoaXMgbWFueSB0aW1lczoifQ==","f11fd0e0-9416-4d39-9136-3cb2d4df1055"]
[debug] [FlutterDriver] Executing Flutter driver command 'getText'
[debug] [FlutterDriver] >>> {"command":"get_text","finderType":"ByText","text":"You have pushed the button this many times:"}
[debug] [FlutterDriver] <<< {"isError":false,"response":{"text":"You have pushed the button this many times:"},"type":"_extensionType","method":"ext.flutter.driver"} | previous command get_text
[debug] [MJSONWP (f11fd0e0)] Responding to client with driver.getText() result: "You have pushed the button this many times:"
[HTTP] <-- GET /wd/hub/session/f11fd0e0-9416-4d39-9136-3cb2d4df1055/element/eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IllvdSBoYXZlIHB1c2hlZCB0aGUgYnV0dG9uIHRoaXMgbWFueSB0aW1lczoifQ==/text 200 120 ms - 117
[HTTP]
[HTTP] --> DELETE /wd/hub/session/f11fd0e0-9416-4d39-9136-3cb2d4df1055
[HTTP] {}
[debug] [MJSONWP (f11fd0e0)] Calling AppiumDriver.deleteSession() with args: ["f11fd0e0-9416-4d39-9136-3cb2d4df1055"]
[debug] [BaseDriver] Event 'quitSessionRequested' logged at 1611733360409 (23:42:40 GMT-0800 (Pacific Standard Time))
[Appium] Removing session f11fd0e0-9416-4d39-9136-3cb2d4df1055 from our master session list
[debug] [FlutterDriver] Deleting Flutter Driver session
[debug] [WD Proxy] Matched '/session/3a13b0b1-b424-4e51-9e5c-78f4875f413a' to command name 'deleteSession'
[debug] [WD Proxy] Proxying [DELETE /session/3a13b0b1-b424-4e51-9e5c-78f4875f413a] to [DELETE http://192.168.4.45:8100/session/C35FD513-52EC-40E5-BC40-2D0A319C26A2] with no body
[FlutterDriver] Connection to ws://127.0.0.1:52315/GouxPMom7Ps=/ws closed
[debug] [WD Proxy] Got response with status 200: {"value":null,"sessionId":null}
[DevCon Factory] Releasing connections for f4da227d7314251e8ed0081590cd813d03064efc device on any port number
[DevCon Factory] Found cached connections to release: ["f4da227d7314251e8ed0081590cd813d03064efc:8100"]
[debug] [DevCon Factory] Cached connections count: 0
[debug] [BaseDriver] Event 'quitSessionFinished' logged at 1611733361560 (23:42:41 GMT-0800 (Pacific Standard Time))
[debug] [MJSONWP (f11fd0e0)] Received response: null
[debug] [MJSONWP (f11fd0e0)] But deleting session, so not returning
[debug] [MJSONWP (f11fd0e0)] Responding to client with driver.deleteSession() result: null
[HTTP] <-- DELETE /wd/hub/session/f11fd0e0-9416-4d39-9136-3cb2d4df1055 200 1157 ms - 76
[HTTP]
```