### PR TITLE
feat: allow to start a session with w3c capabilities

### DIFF
--- a/driver/lib/driver.ts
+++ b/driver/lib/driver.ts
@@ -1,7 +1,7 @@
 import { BaseDriver, errors } from 'appium-base-driver';
 import { IsolateSocket } from './sessions/isolate_socket';
 
-import { desiredCapConstraints, IDesiredCapConstraints } from './desired-caps';
+import { IDesiredCapConstraints } from './desired-caps';
 import { log as logger } from './logger';
 
 import { executeElementCommand } from './sessions/observatory';
@@ -15,7 +15,6 @@ import { click, longTap, performTouch, tap, tapEl } from './commands/gesture';
 import { getScreenshot } from './commands/screen';
 
 class FlutterDriver extends BaseDriver {
-  public desiredCapConstraints: IDesiredCapConstraints;
   public socket: IsolateSocket | null = null;
   public locatorStrategies = [`key`, `css selector`];
   public proxydriver: any;
@@ -56,16 +55,13 @@ class FlutterDriver extends BaseDriver {
 
   constructor(opts, shouldValidateCaps: boolean) {
     super(opts, shouldValidateCaps);
-
-    this.desiredCapConstraints = desiredCapConstraints;
-
     this.proxydriver = null;
     this.device = null;
   }
 
-  public async createSession(caps: IDesiredCapConstraints) {
-    const [sessionId] = await super.createSession(caps);
-    return createSession.bind(this)(caps, sessionId);
+  public async createSession(...args) {
+    const [sessionId, caps] = await super.createSession(...JSON.parse(JSON.stringify(args)));
+    return createSession.bind(this)(sessionId, caps, ...JSON.parse(JSON.stringify(args)));
   }
 
   public async deleteSession() {
@@ -88,13 +84,6 @@ class FlutterDriver extends BaseDriver {
     const res = super.validateDesiredCaps(caps);
     if (!res) {
       return res;
-    }
-    // @ts-ignore
-    if (caps.deviceName.toLowerCase() === `android`) {
-      if (!caps.avd) {
-        const msg = `The desired capabilities must include avd`;
-        logger.errorAndThrow(msg);
-      }
     }
 
     // finally, return true since the superclass check passed, as did this

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -8,21 +8,20 @@ const execPromise = promisify(exec);
 import AndroidDriver from 'appium-uiautomator2-driver';
 import { log } from '../logger';
 import { connectSocket, processLogToGetobservatory } from './observatory';
-const setupNewAndroidDriver = async (caps) => {
+const setupNewAndroidDriver = async (...args) => {
   const androidArgs = {
     javascriptEnabled: true,
   };
   const androiddriver = new AndroidDriver(androidArgs);
-  const capsCopy = Object.assign({}, caps, { newCommandTimeout: 0 });
-
-  await androiddriver.createSession(capsCopy);
+  // const capsCopy = Object.assign({}, caps, { "appium:newCommandTimeout": 0 });
+  await androiddriver.createSession(...args);
 
   return androiddriver;
 };
 
-export const startAndroidSession = async (caps) => {
-  log.info(`Starting an Android proxy session`);
-  const androiddriver = await setupNewAndroidDriver(caps);
+export const startAndroidSession = async (caps, ...args) => {
+  log.info(`Starting an Android proxy session: ${JSON.stringify(args)}`);
+  const androiddriver = await setupNewAndroidDriver(...args);
   const observatoryWsUri = getObservatoryWsUri(androiddriver , caps);
   return Promise.all([
     androiddriver,

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -13,7 +13,6 @@ const setupNewAndroidDriver = async (...args) => {
     javascriptEnabled: true,
   };
   const androiddriver = new AndroidDriver(androidArgs);
-  // const capsCopy = Object.assign({}, caps, { "appium:newCommandTimeout": 0 });
   await androiddriver.createSession(...args);
 
   return androiddriver;

--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -19,7 +19,7 @@ const setupNewAndroidDriver = async (...args) => {
 };
 
 export const startAndroidSession = async (caps, ...args) => {
-  log.info(`Starting an Android proxy session: ${JSON.stringify(args)}`);
+  log.info(`Starting an Android proxy session`);
   const androiddriver = await setupNewAndroidDriver(...args);
   const observatoryWsUri = getObservatoryWsUri(androiddriver , caps);
   return Promise.all([

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -12,21 +12,21 @@ import B from 'bluebird';
 const LOCALHOST = '127.0.0.1';
 const PORT_CLOSE_TIMEOUT = 15 * 1000; // 15 seconds
 
-const setupNewIOSDriver = async (caps) => {
+const setupNewIOSDriver = async (...args) => {
   const iosArgs = {
     javascriptEnabled: true,
   };
 
   const iosdriver = new XCUITestDriver(iosArgs);
-  const capsCopy = Object.assign({}, caps, { newCommandTimeout: 0 });
-  await iosdriver.createSession(capsCopy);
+  // const capsCopy = Object.assign({}, caps, { newCommandTimeout: 0 });
+  await iosdriver.createSession(...args);
 
   return iosdriver;
 };
 
-export const startIOSSession = async (caps) => {
+export const startIOSSession = async (caps, ...args) => {
   log.info(`Starting an IOS proxy session`);
-  const iosdriver = await setupNewIOSDriver(caps);
+  const iosdriver = await setupNewIOSDriver(...args);
   const observatoryWsUri = await getObservatoryWsUri(iosdriver);
   return Promise.all([
     iosdriver,

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -18,7 +18,6 @@ const setupNewIOSDriver = async (...args) => {
   };
 
   const iosdriver = new XCUITestDriver(iosArgs);
-  // const capsCopy = Object.assign({}, caps, { newCommandTimeout: 0 });
   await iosdriver.createSession(...args);
 
   return iosdriver;

--- a/driver/lib/sessions/session.ts
+++ b/driver/lib/sessions/session.ts
@@ -5,17 +5,17 @@ import { startAndroidSession } from './android';
 import { startIOSSession } from './ios';
 
 // tslint:disable-next-line:variable-name
-export const createSession = async function(this: FlutterDriver, caps, sessionId)  {
+export const createSession = async function(this: FlutterDriver, sessionId, caps, ...args)  {
     try {
       // setup proxies - if platformName is not empty, make it less case sensitive
       if (caps.platformName !== null) {
         const appPlatform = caps.platformName.toLowerCase();
         switch (appPlatform) {
           case `ios`:
-            [this.proxydriver, this.socket] = await startIOSSession(caps);
+            [this.proxydriver, this.socket] = await startIOSSession(caps, ...args);
             break;
           case `android`:
-            [this.proxydriver, this.socket] = await startAndroidSession(caps);
+            [this.proxydriver, this.socket] = await startAndroidSession(caps, ...args);
             break;
           default:
             log.errorAndThrow(


### PR DESCRIPTION
The current flutter driver does not work only  W3C capabilities like the below:

> {"capabilities":{"alwaysMatch":{"platformName":"android","appium:udid":"emulator-5554","appium:deviceName":"android","appium:automationName":"flutter","appium:app":"path/to/app"}}}

This is because this driver gives only the 1st argument for `createSession`. It is an array and the 3rd argument may have W3C capabilities. This driver must handle it.
I also gives arguments with `...JSON.parse(JSON.stringify(args))` as deep close to avoid overriding the capabilities.


I tested with only W3C, W3C and MJSONWP, and only MJSONWP capabilities. They were able to establish each session well.

I also removed a blocking code, `avd` check, for Android real device testing which did not work well before.