### PR TITLE
fix: ensure to call deletion method in ios/android when observatory failed

### DIFF
--- a/driver/lib/sessions/android.ts
+++ b/driver/lib/sessions/android.ts
@@ -21,7 +21,13 @@ const setupNewAndroidDriver = async (...args) => {
 export const startAndroidSession = async (caps, ...args) => {
   log.info(`Starting an Android proxy session`);
   const androiddriver = await setupNewAndroidDriver(...args);
-  const observatoryWsUri = getObservatoryWsUri(androiddriver , caps);
+  let observatoryWsUri;
+  try {
+    observatoryWsUri = await getObservatoryWsUri(androiddriver , caps);
+  } catch (e) {
+    await androiddriver.deleteSession();
+    throw e;
+  };
   return Promise.all([
     androiddriver,
     connectSocket(await observatoryWsUri, caps.retryBackoffTime, caps.maxRetryCount),

--- a/driver/lib/sessions/ios.ts
+++ b/driver/lib/sessions/ios.ts
@@ -26,7 +26,13 @@ const setupNewIOSDriver = async (...args) => {
 export const startIOSSession = async (caps, ...args) => {
   log.info(`Starting an IOS proxy session`);
   const iosdriver = await setupNewIOSDriver(...args);
-  const observatoryWsUri = await getObservatoryWsUri(iosdriver);
+  let observatoryWsUri;
+  try {
+    observatoryWsUri = await getObservatoryWsUri(iosdriver);
+  } catch (e) {
+    await iosdriver.deleteSession();
+    throw e;
+  };
   return Promise.all([
     iosdriver,
     connectSocket(observatoryWsUri, caps.retryBackoffTime, caps.maxRetryCount),


### PR DESCRIPTION
I found current implementation did not call `deleteSession` in Android/iOS drivers when `getObservatoryWsUri` failed.
So, the next will get unexpected errors.
We should ensure to call deleteSession properly then.