### PR TITLE
python: fix descendant by ancestor

### DIFF
--- a/finder/python/README.md
+++ b/finder/python/README.md
@@ -41,6 +41,9 @@ twine upload dist/Appium-Flutter-Finder-X.X.tar.gz
 ```
 
 # Changelog
+- 0.1.4
+    - Remove whitespaces from the decoded JSON
+    - Fix `by_ancestor` and `by_descendant`
 - 0.1.3
     - Allow `from appium_flutter_finder import FlutterElement, FlutterFinder`
 - 0.1.2

--- a/finder/python/appium_flutter_finder/flutter_finder.py
+++ b/finder/python/appium_flutter_finder/flutter_finder.py
@@ -3,6 +3,7 @@ import json
 
 from appium.webdriver.webelement import WebElement
 
+
 def _bytes(value):
     try:
         return bytes(value, 'UTF-8')  # Python 3
@@ -72,20 +73,23 @@ class FlutterFinder(object):
         ))
 
     def _serialize(self, finder_dict):
-        return base64.b64encode(_bytes(json.dumps(finder_dict))).decode('UTF-8')
+        return base64.b64encode(_bytes(
+            json.dumps(finder_dict, separators=(',', ':')))).decode('UTF-8')
 
     def _by_ancestor_or_descendant(self, type_, serialized_finder, matching, match_root=False):
         param = dict(finderType=type_, matchRoot=match_root)
 
         try:
-            finder = json.dumps(base64.b64decode(serialized_finder))
+            finder = json.loads(base64.b64decode(
+                serialized_finder).decode('utf-8'))
         except:
             finder = dict()
+
         for finder_key, finder_value in finder.items():
             param['of_{}'.format(finder_key)] = finder_value
 
         try:
-            matching = json.dumps(base64.b64decode(matching))
+            matching = json.loads(base64.b64decode(matching).decode('utf-8'))
         except:
             matching = dict()
         for matching_key, matching_value in matching.items():

--- a/finder/python/setup.py
+++ b/finder/python/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='Appium-Flutter-Finder',
-    version='0.1.3',
+    version='0.1.4',
     description='An extention of finder for Appium flutter',
     long_description=io.open(os.path.join(os.path.dirname('__file__'), 'README.md'), encoding='utf-8').read(),
     long_description_content_type='text/markdown',

--- a/finder/python/tests/flutter_finer_tests.py
+++ b/finder/python/tests/flutter_finer_tests.py
@@ -1,0 +1,63 @@
+import unittest
+
+import appium_flutter_finder.flutter_finder as finder
+
+
+class FlutterFinderTest(unittest.TestCase):
+    def test_by_ancestor(self):
+        assert finder.FlutterFinder().by_ancestor(
+            finder.FlutterFinder().by_ancestor(
+                finder.FlutterFinder().page_back(),
+                finder.FlutterFinder().page_back()
+            ),
+            finder.FlutterFinder().by_ancestor(
+                finder.FlutterFinder().page_back(),
+                finder.FlutterFinder().page_back()
+            )
+        ) == \
+            'eyJmaW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaFJvb3QiOmZhbHNlLCJvZl9maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJvZl9tYXRjaFJvb3QiOmZhbHNlLCJvZl9vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJvZl9tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ=='
+
+    def test_by_descendant(self):
+        assert finder.FlutterFinder().by_descendant(
+            finder.FlutterFinder().by_descendant(
+                finder.FlutterFinder().page_back(),
+                finder.FlutterFinder().page_back()
+            ),
+            finder.FlutterFinder().by_descendant(
+                finder.FlutterFinder().page_back(),
+                finder.FlutterFinder().page_back()
+            )
+        ) == \
+            'eyJmaW5kZXJUeXBlIjoiRGVzY2VuZGFudCIsIm1hdGNoUm9vdCI6ZmFsc2UsIm9mX2ZpbmRlclR5cGUiOiJEZXNjZW5kYW50Iiwib2ZfbWF0Y2hSb290IjpmYWxzZSwib2Zfb2ZfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwib2ZfbWF0Y2hpbmdfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwibWF0Y2hpbmdfZmluZGVyVHlwZSI6IkRlc2NlbmRhbnQiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ=='
+
+    def test_by_semantics_label(self):
+        assert finder.FlutterFinder().by_semantics_label('simple') == \
+            'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjpmYWxzZSwibGFiZWwiOiJzaW1wbGUifQ=='
+
+    def test_by_semantics_label_regex(self):
+        assert finder.FlutterFinder().by_semantics_label(r'complicated', isRegExp=True) == \
+            'eyJmaW5kZXJUeXBlIjoiQnlTZW1hbnRpY3NMYWJlbCIsImlzUmVnRXhwIjp0cnVlLCJsYWJlbCI6ImNvbXBsaWNhdGVkIn0='
+
+    def test_by_tooltip(self):
+        assert finder.FlutterFinder().by_tooltip('myText') == \
+            'eyJmaW5kZXJUeXBlIjoiQnlUb29sdGlwTWVzc2FnZSIsInRleHQiOiJteVRleHQifQ=='
+
+    def test_by_type(self):
+        assert finder.FlutterFinder().by_type('myText') == \
+            'eyJmaW5kZXJUeXBlIjoiQnlUeXBlIiwidHlwZSI6Im15VGV4dCJ9'
+
+    def test_by_key_value_int(self):
+        assert finder.FlutterFinder().by_value_key(42) == \
+            'eyJmaW5kZXJUeXBlIjoiQnlWYWx1ZUtleSIsImtleVZhbHVlU3RyaW5nIjo0Miwia2V5VmFsdWVUeXBlIjoiaW50In0='
+
+    def test_by_key_value_string(self):
+        assert finder.FlutterFinder().by_value_key('42') == \
+            'eyJmaW5kZXJUeXBlIjoiQnlWYWx1ZUtleSIsImtleVZhbHVlU3RyaW5nIjoiNDIiLCJrZXlWYWx1ZVR5cGUiOiJTdHJpbmcifQ=='
+
+    def test_page_back(self):
+        assert finder.FlutterFinder().page_back() == \
+            'eyJmaW5kZXJUeXBlIjoiUGFnZUJhY2sifQ=='
+
+    def test_by_text(self):
+        assert finder.FlutterFinder().by_text('This is 2nd route') == \
+            'eyJmaW5kZXJUeXBlIjoiQnlUZXh0IiwidGV4dCI6IlRoaXMgaXMgMm5kIHJvdXRlIn0='


### PR DESCRIPTION
Fixes https://github.com/truongsinh/appium-flutter-driver/issues/161
https://pypi.org/project/Appium-Flutter-Finder/0.1.4/

---

1. added test code
2. fixed by_ancestor and by_descendant
3. removed whitespace (`separators=(',', ':')`) (This changes itself should not change anything.)