### PR TITLE
modify bug on _by_ancestor_or_descendant function

### DIFF
--- a/finder/python/appium_flutter_finder/flutter_finder.py
+++ b/finder/python/appium_flutter_finder/flutter_finder.py
@@ -85,14 +85,18 @@ class FlutterFinder(object):
         except:
             finder = dict()
 
+        param.setdefault('of', {})
         for finder_key, finder_value in finder.items():
-            param['of_{}'.format(finder_key)] = finder_value
+            param['of'].setdefault(finder_key, finder_value)
+        param['of'] = json.dumps(param['of'])
 
         try:
             matching = json.loads(base64.b64decode(matching).decode('utf-8'))
         except:
             matching = dict()
+        param.setdefault('matching', {})
         for matching_key, matching_value in matching.items():
-            param['matching_{}'.format(matching_key)] = matching_value
+            param['matching'].setdefault(matching_key, matching_value)
+        param['matching'] = json.dumps(param['matching'])
 
         return self._serialize(param)

--- a/finder/python/tests/flutter_finer_tests.py
+++ b/finder/python/tests/flutter_finer_tests.py
@@ -14,10 +14,22 @@ class FlutterFinderTest(unittest.TestCase):
                 finder.FlutterFinder().page_back(),
                 finder.FlutterFinder().page_back()
             )
-        ) == \
-            'eyJmaW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaFJvb3QiOmZhbHNlLCJvZl9maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJvZl9tYXRjaFJvb3QiOmZhbHNlLCJvZl9vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJvZl9tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19maW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ=='
+        ) == (
+            'eyJmaW5kZXJUeXBlIjoiQW5jZXN0b3IiLCJtYXRjaFJvb3QiOmZhbHNlLCJvZiI6IntcImZpbmRlclR5cGVcIjogXCJBbmNlc3RvclwiLCBcIm1hdGNoUm9vdFwiOiBmYWxzZSwgXCJvZlwiOiBcIntcXFwiZmluZGVyVHlwZVxcXCI6IFxcXCJQYWdlQmFja1xc'
+            'XCJ9XCIsIFwibWF0Y2hpbmdcIjogXCJ7XFxcImZpbmRlclR5cGVcXFwiOiBcXFwiUGFnZUJhY2tcXFwifVwifSIsIm1hdGNoaW5nIjoie1wiZmluZGVyVHlwZVwiOiBcIkFuY2VzdG9yXCIsIFwibWF0Y2hSb290XCI6IGZhbHNlLCBcIm9mXCI6IFwie1xcXCJm'
+            'aW5kZXJUeXBlXFxcIjogXFxcIlBhZ2VCYWNrXFxcIn1cIiwgXCJtYXRjaGluZ1wiOiBcIntcXFwiZmluZGVyVHlwZVxcXCI6IFxcXCJQYWdlQmFja1xcXCJ9XCJ9In0=')
 
     def test_by_descendant(self):
+        print(finder.FlutterFinder().by_descendant(
+            finder.FlutterFinder().by_descendant(
+                finder.FlutterFinder().page_back(),
+                finder.FlutterFinder().page_back()
+            ),
+            finder.FlutterFinder().by_descendant(
+                finder.FlutterFinder().page_back(),
+                finder.FlutterFinder().page_back()
+            )
+        ))
         assert finder.FlutterFinder().by_descendant(
             finder.FlutterFinder().by_descendant(
                 finder.FlutterFinder().page_back(),
@@ -27,8 +39,10 @@ class FlutterFinderTest(unittest.TestCase):
                 finder.FlutterFinder().page_back(),
                 finder.FlutterFinder().page_back()
             )
-        ) == \
-            'eyJmaW5kZXJUeXBlIjoiRGVzY2VuZGFudCIsIm1hdGNoUm9vdCI6ZmFsc2UsIm9mX2ZpbmRlclR5cGUiOiJEZXNjZW5kYW50Iiwib2ZfbWF0Y2hSb290IjpmYWxzZSwib2Zfb2ZfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwib2ZfbWF0Y2hpbmdfZmluZGVyVHlwZSI6IlBhZ2VCYWNrIiwibWF0Y2hpbmdfZmluZGVyVHlwZSI6IkRlc2NlbmRhbnQiLCJtYXRjaGluZ19tYXRjaFJvb3QiOmZhbHNlLCJtYXRjaGluZ19vZl9maW5kZXJUeXBlIjoiUGFnZUJhY2siLCJtYXRjaGluZ19tYXRjaGluZ19maW5kZXJUeXBlIjoiUGFnZUJhY2sifQ=='
+        ) == (
+            'eyJmaW5kZXJUeXBlIjoiRGVzY2VuZGFudCIsIm1hdGNoUm9vdCI6ZmFsc2UsIm9mIjoie1wiZmluZGVyVHlwZVwiOiBcIkRlc2NlbmRhbnRcIiwgXCJtYXRjaFJvb3RcIjogZmFsc2UsIFwib2ZcIjogXCJ7XFxcImZpbmRlclR5cGVcXFwiOiBcXFwiUGFnZUJhY'
+            '2tcXFwifVwiLCBcIm1hdGNoaW5nXCI6IFwie1xcXCJmaW5kZXJUeXBlXFxcIjogXFxcIlBhZ2VCYWNrXFxcIn1cIn0iLCJtYXRjaGluZyI6IntcImZpbmRlclR5cGVcIjogXCJEZXNjZW5kYW50XCIsIFwibWF0Y2hSb290XCI6IGZhbHNlLCBcIm9mXCI6IFwie1'
+            'xcXCJmaW5kZXJUeXBlXFxcIjogXFxcIlBhZ2VCYWNrXFxcIn1cIiwgXCJtYXRjaGluZ1wiOiBcIntcXFwiZmluZGVyVHlwZVxcXCI6IFxcXCJQYWdlQmFja1xcXCJ9XCJ9In0=')
 
     def test_by_semantics_label(self):
         assert finder.FlutterFinder().by_semantics_label('simple') == \

--- a/finder/python/tests/flutter_finer_tests.py
+++ b/finder/python/tests/flutter_finer_tests.py
@@ -20,16 +20,6 @@ class FlutterFinderTest(unittest.TestCase):
             'aW5kZXJUeXBlXFxcIjogXFxcIlBhZ2VCYWNrXFxcIn1cIiwgXCJtYXRjaGluZ1wiOiBcIntcXFwiZmluZGVyVHlwZVxcXCI6IFxcXCJQYWdlQmFja1xcXCJ9XCJ9In0=')
 
     def test_by_descendant(self):
-        print(finder.FlutterFinder().by_descendant(
-            finder.FlutterFinder().by_descendant(
-                finder.FlutterFinder().page_back(),
-                finder.FlutterFinder().page_back()
-            ),
-            finder.FlutterFinder().by_descendant(
-                finder.FlutterFinder().page_back(),
-                finder.FlutterFinder().page_back()
-            )
-        ))
         assert finder.FlutterFinder().by_descendant(
             finder.FlutterFinder().by_descendant(
                 finder.FlutterFinder().page_back(),


### PR DESCRIPTION
Original code of construct command as following:
```
        finder = FlutterFinder()
        key_finder = finder.by_value_key("video_name_skip")
        sub_key_finder = finder.by_value_key("txt_skip")
        final_finder = finder.by_descendant(key_finder, sub_key_finder)
        ele=FlutterElement(driver, final_finder)
        print(ele.text)

```

output:
[debug] [FlutterDriver] Executing Flutter driver command 'getText'
[debug] [FlutterDriver] >>>{"command":"get_text","finderType":"Descendant","matchRoot":false,"of_finderType":"ByValueKey","of_keyValueString":"video_name_skip","of_keyValueType":"String","matching_finderType":"ByValueKey","matching_keyValueString":"txt_skip","matching_keyValueType":"String"}
[debug] [FlutterDriver] <<< {"isError":true,"response":"Uncaught extension error while executing get_text: Null check operator used on a null value\n#0 Descendant.deserialize (package:flutter_driver/src/common/find.dart:310:55)\n#1 DeserializeFinderFactory.deserializeFinder (package:flutter_driver/src/common/deserialization_factory.dart:32:44)\n#2 FlutterDriverExtension.deserializeFinder (package:flutter_driver/src/extension/extension.dart:405:18)\n#3 new CommandWithTarget.deserialize (package:flutter_driver/src/common/find.dart:32:30)\n#4 new GetText.deserialize (package:flutter_driver/src/common/text.dart:15:97)\n#5 DeserializeCommandFactory.deserializeCommand (package:flutter_driver/src/common/deserialization_factory.dart:49:39)\n#6 FlutterDriverExtension.deserializeCommand (package:flutter_driver/src/extension/extension.dart:425:18)\n#7 FlutterDriverExtension.call (package:flutter_driver/src/extension/extension.dart:371:31)\n#8 BindingBase.registerServiceExtension. (package:flutter/src/foundation/binding.dart:597:32)\n\n","type":"_extensionType","method":"ext.flutter.driver"} | previous command get_text
[debug] [MJSONWP (ae86ce36)] Encountered internal error running command: Error: Cannot execute command get_text, server reponse {
[debug] [MJSONWP (ae86ce36)] "isError": true,
[debug] [MJSONWP (ae86ce36)] "response": "Uncaught extension error while executing get_text: Null check operator used on a null value\n#0 Descendant.deserialize (package:flutter_driver/src/common/find.dart:310:55)\n#1 DeserializeFinderFactory.deserializeFinder (package:flutter_driver/src/common/deserialization_factory.dart:32:44)\n#2 FlutterDriverExtension.deserializeFinder (package:flutter_driver/src/extension/extension.dart:405:18)\n#3 new CommandWithTarget.deserialize (package:flutter_driver/src/common/find.dart:32:30)\n#4 new GetText.deserialize (package:flutter_driver/src/common/text.dart:15:97)\n#5 DeserializeCommandFactory.deserializeCommand (package:flutter_driver/src/common/deserialization_factory.dart:49:39)\n#6 FlutterDriverExtension.deserializeCommand (package:flutter_driver/src/extension/extension.dart:425:18)\n#7 FlutterDriverExtension.call (package:flutter_driver/src/extension/extension.dart:371:31)\n#8 BindingBase.registerServiceExtension. (package:flutter/src/foundation/binding.dart:597:32)\n\n",
[debug] [MJSONWP (ae86ce36)] "type": "_extensionType",
[debug] [MJSONWP (ae86ce36)] "method": "ext.flutter.driver"
[debug] [MJSONWP (ae86ce36)] }
[debug] [MJSONWP (ae86ce36)] at FlutterDriver.exports.executeElementCommand (/usr/local/lib/node_modules/appium/node_modules/appium-flutter-driver/lib/sessions/observatory.ts:126:11)
[debug] [MJSONWP (ae86ce36)] at processTicksAndRejections (internal/process/task_queues.js:97:5)
[debug] [MJSONWP (ae86ce36)] at FlutterDriver.exports.getText (/usr/local/lib/node_modules/appium/node_modules/appium-flutter-driver/lib/commands/element.ts:4:20)

Compared with flutter driver locally:
VMServiceFlutterDriver: >>> {command: tap, finderType: Descendant, of: {"finderType":"ByValueKey","keyValueString":"video_name_skip","keyValueType":"String"}, matching: {"finderType":"ByValueKey","keyValueString":"txt_skip","keyValueType":"String"}, matchRoot: false, firstMatchOnly: false}

Above error may be raised by following code segment of find.dart:
final Map<String, String> jsonOfMatcher =
        Map<String, String>.from(jsonDecode(json['of']!) as Map<String, dynamic>);
final Map<String, String> jsonMatchingMatcher =
        Map<String, String>.from(jsonDecode(json['matching']!) as Map<String, dynamic>);

So may be _by_ancestor_or_descendant should be updated.
